### PR TITLE
fix: handle newline-separated thoughts in commit message

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -227,7 +227,14 @@ function checkCommitMessage(message: string) {
 
 function removeThoughts(message: string) {
   // e.g. gemini-2.5-pro-exp-03-25 contains <thought>...</thought>
-  return message.replace(/<thought>[\s\S]*?<\/thought>/gm, '');
+  message = message.replace(/<thought>[\s\S]*?<\/thought>/gm, '');
+
+  // eg claude-3.7-sonnet thought ... \n\n ...
+  if (message.indexOf('\n') != -1) {
+    // get the last line from newline-separated lines
+    return message.split('\n').pop() || message;
+  }
+  return message;
 }
 
 const COMMIT_PROMPT = `


### PR DESCRIPTION
提示词没有完全禁用掉、带 thought 的会有换行所以取最后一个如果没值 还使用原来的 message
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/7044a6ad-97e3-49e2-83ee-15aa4a11ddd8" />
