### PR TITLE
fix: plugin extension slashCommands type exception

### DIFF
--- a/src/slashCommand.ts
+++ b/src/slashCommand.ts
@@ -59,6 +59,7 @@ export class SlashCommandManager {
     const pluginSlashCommands = await context.apply({
       hook: 'command',
       args: [],
+      memo: [],
       type: PluginHookType.SeriesMerge,
     });
     return new SlashCommandManager({


### PR DESCRIPTION
<img width="765" height="339" alt="image" src="https://github.com/user-attachments/assets/db25cc34-3f29-4844-9e31-a577b7bea4ef" />
