### PR TITLE
feat(browser): optimize right panel width calculation and fix resize handle hover

### DIFF
--- a/browser/src/components/ChatLayout/ResizeHandle.tsx
+++ b/browser/src/components/ChatLayout/ResizeHandle.tsx
@@ -9,18 +9,19 @@ const useResizeHandleStyles = createStyles(({ css }) => ({
     background: #e5e5e5;
     cursor: col-resize;
     position: relative;
+    transform-origin: center;
     transition:
-      width 0.2s ease,
+      transform 0.2s ease,
       background 0.2s ease;
 
     &:hover {
       background: #7357ff;
-      width: 3px;
+      transform: scaleX(3);
     }
 
     &:active {
       background: #7357ff;
-      width: 3px;
+      transform: scaleX(3);
     }
   `,
 }));
@@ -69,9 +70,9 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
         const rightWidthPercent =
           ((containerWidth - mouseX) / containerWidth) * 100;
 
-        // Boundary constraints: right panel 20% - 80%
+        // Boundary constraints: right panel 20% - dynamic max based on screen size
         const minRight = 20;
-        const maxRight = 80;
+        const maxRight = layout.actions.calculateRightPanelWidth();
         const clampedRightPercent = Math.max(
           minRight,
           Math.min(maxRight, rightWidthPercent),

--- a/browser/src/state/layout.ts
+++ b/browser/src/state/layout.ts
@@ -20,12 +20,36 @@ export const actions = {
     state.sidebarCollapsed = collapsed;
   },
   toggleRightPanel: () => {
+    const wasExpanded = state.rightPanelExpanded;
     state.rightPanelExpanded = !state.rightPanelExpanded;
+
+    // Calculate optimal width when first opening the panel
+    if (!wasExpanded && state.rightPanelExpanded) {
+      const optimalWidth = actions.calculateRightPanelWidth();
+      state.rightPanelWidthPercent = optimalWidth;
+    }
   },
   setRightPanelExpanded: (expanded: boolean) => {
     state.rightPanelExpanded = expanded;
   },
   setRightPanelWidthPercent: (widthPercent: number) => {
-    state.rightPanelWidthPercent = Math.max(20, Math.min(80, widthPercent));
+    const maxWidth = actions.calculateRightPanelWidth();
+    state.rightPanelWidthPercent = Math.max(
+      20,
+      Math.min(maxWidth, widthPercent),
+    );
+  },
+  calculateRightPanelWidth: () => {
+    const containerWidth = window.innerWidth;
+    const inputMaxWidth = 800;
+    const inputPadding = 48; // 24px * 2
+    const reservedLeftSpace = inputMaxWidth + inputPadding;
+
+    // Right panel width = 100vw - 800px - 48px
+    const rightPixels = containerWidth - reservedLeftSpace;
+    const rightPercent = (rightPixels / containerWidth) * 100;
+
+    // Ensure minimum width of 20%
+    return Math.max(20, rightPercent);
   },
 };


### PR DESCRIPTION
布局优化，右侧面板打开时，左侧面板输入框两侧保留24px间隔
<img width="3082" height="1336" alt="image" src="https://github.com/user-attachments/assets/03945cb8-e7c8-467c-afae-c2f1c7756fc6" />
