### PR TITLE
feat(slash-command): add session-specific model support to chat store

### DIFF
--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -74,7 +74,6 @@ interface AppState {
   version: string;
   theme: Theme;
   model: string | null;
-
   modelContextLimit: number;
   providers: ProvidersMap;
   sessionId: string | null;
@@ -160,7 +159,6 @@ interface AppActions {
   denyPlan: () => void;
   resumeSession: (sessionId: string, logFile: string) => Promise<void>;
   setModel: (model: string) => void;
-
   approveToolUse: ({
     toolUse,
     category,
@@ -200,7 +198,6 @@ export const useAppStore = create<AppStore>()(
       logFile: null,
       theme: 'light',
       model: null,
-
       modelContextLimit: null,
       providers: {},
       status: 'idle',


### PR DESCRIPTION
指令支持 自定义 model
<img width="662" height="661" alt="image" src="https://github.com/user-attachments/assets/999fe9ce-4361-4656-bc1c-9faa0696b770" />
