### PR TITLE
feat: improve image placeholder format to display size and filename

### DIFF
--- a/src/ui/TextInput/hooks/useTextInput.ts
+++ b/src/ui/TextInput/hooks/useTextInput.ts
@@ -40,7 +40,7 @@ type UseTextInputProps = {
   invert: (text: string) => string;
   themeText: (text: string) => string;
   columns: number;
-  onImagePaste?: (base64Image: string) => void;
+  onImagePaste?: (base64Image: string, filename?: string) => void;
   disableCursorMovementForUpDownKeys?: boolean;
   externalOffset: number;
   onOffsetChange: (offset: number) => void;
@@ -304,10 +304,10 @@ export function useTextInput({
     return (input: string) => {
       switch (true) {
         // Home key
-        case input == '\x1b[H' || input == '\x1b[1~':
+        case input === '\x1b[H' || input === '\x1b[1~':
           return cursor.startOfLine();
         // End key
-        case input == '\x1b[F' || input == '\x1b[4~':
+        case input === '\x1b[F' || input === '\x1b[4~':
           return cursor.endOfLine();
         default:
           // Check if input might be an image path and handle accordingly
@@ -327,7 +327,7 @@ export function useTextInput({
     if (nextCursor) {
       if (!cursor.equals(nextCursor)) {
         setOffset(nextCursor.offset);
-        if (cursor.text != nextCursor.text) {
+        if (cursor.text !== nextCursor.text) {
           onChange(nextCursor.text || '');
         }
       }

--- a/src/ui/TextInput/index.tsx
+++ b/src/ui/TextInput/index.tsx
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { type Key, Text, useInput } from 'ink';
+import { basename } from 'pathe';
 import React from 'react';
 import { PASTE_CONFIG } from '../constants';
 import { darkTheme } from './constant';
@@ -113,6 +114,7 @@ export type Props = {
    */
   readonly onImagePaste?: (
     base64Image: string,
+    filename?: string,
   ) => Promise<{ prompt?: string }> | void;
 
   /**
@@ -253,7 +255,11 @@ export default function TextInput({
           try {
             const imageResult = await processImageFromPath(mergedInput);
             if (imageResult) {
-              const imagePromptResult = await onImagePaste(imageResult.base64);
+              const fileName = basename(imageResult.path);
+              const imagePromptResult = await onImagePaste(
+                imageResult.base64,
+                fileName,
+              );
               if (imagePromptResult?.prompt) {
                 const { newValue, newCursorOffset } = insertTextAtCursor(
                   imagePromptResult.prompt,
@@ -425,7 +431,7 @@ export default function TextInput({
         : chalk.inverse(' ');
   }
 
-  const showPlaceholder = originalValue.length == 0 && placeholder;
+  const showPlaceholder = originalValue.length === 0 && placeholder;
   return (
     <Text wrap="truncate-end" dimColor={isDimmed}>
       {showPlaceholder ? renderedPlaceholder : renderedValue}

--- a/src/ui/TextInput/utils/imageDimensions.ts
+++ b/src/ui/TextInput/utils/imageDimensions.ts
@@ -1,0 +1,130 @@
+/**
+ * 获取图片尺寸的工具函数
+ */
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * 从 base64 图片数据中获取图片尺寸
+ * @param base64Data base64 编码的图片数据
+ * @returns 图片尺寸信息
+ */
+export function getImageDimensions(base64Data: string): ImageDimensions {
+  try {
+    const buffer = Buffer.from(base64Data, 'base64');
+
+    // PNG 格式
+    if (
+      buffer[0] === 137 &&
+      buffer[1] === 80 &&
+      buffer[2] === 78 &&
+      buffer[3] === 71
+    ) {
+      return getPNGDimensions(buffer);
+    }
+
+    // JPEG 格式
+    if (buffer[0] === 255 && buffer[1] === 216) {
+      return getJPEGDimensions(buffer);
+    }
+
+    // GIF 格式
+    if (buffer[0] === 71 && buffer[1] === 73 && buffer[2] === 70) {
+      return getGIFDimensions(buffer);
+    }
+
+    // WebP 格式
+    if (
+      buffer[0] === 82 &&
+      buffer[1] === 73 &&
+      buffer[2] === 70 &&
+      buffer[3] === 70
+    ) {
+      return getWebPDimensions(buffer);
+    }
+
+    // 默认返回 100x100
+    return { width: 100, height: 100 };
+  } catch {
+    return { width: 100, height: 100 };
+  }
+}
+
+function getPNGDimensions(buffer: Buffer): ImageDimensions {
+  if (buffer.length < 24) return { width: 100, height: 100 };
+
+  // PNG IHDR chunk 从第 16 字节开始
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+
+  return { width, height };
+}
+
+function getJPEGDimensions(buffer: Buffer): ImageDimensions {
+  let offset = 2; // 跳过 FF D8
+
+  while (offset < buffer.length) {
+    if (buffer[offset] !== 0xff) break;
+
+    const marker = buffer[offset + 1];
+
+    // SOF0, SOF1, SOF2 标记包含尺寸信息
+    if (marker >= 0xc0 && marker <= 0xc3) {
+      if (offset + 9 < buffer.length) {
+        const height = buffer.readUInt16BE(offset + 5);
+        const width = buffer.readUInt16BE(offset + 7);
+        return { width, height };
+      }
+    }
+
+    // 跳过当前段
+    if (offset + 3 < buffer.length) {
+      const segmentLength = buffer.readUInt16BE(offset + 2);
+      offset += 2 + segmentLength;
+    } else {
+      break;
+    }
+  }
+
+  return { width: 100, height: 100 };
+}
+
+function getGIFDimensions(buffer: Buffer): ImageDimensions {
+  if (buffer.length < 10) return { width: 100, height: 100 };
+
+  // GIF 尺寸信息在 6-9 字节
+  const width = buffer.readUInt16LE(6);
+  const height = buffer.readUInt16LE(8);
+
+  return { width, height };
+}
+
+function getWebPDimensions(buffer: Buffer): ImageDimensions {
+  if (buffer.length < 30) return { width: 100, height: 100 };
+
+  // WebP 格式比较复杂，这里简化处理
+  // 实际项目中可能需要更复杂的解析
+  try {
+    // 尝试从 VP8 或 VP8L 块中获取尺寸
+    let offset = 12; // 跳过 RIFF 头部
+
+    while (offset < buffer.length - 8) {
+      const chunkType = buffer.toString('ascii', offset, offset + 4);
+      const chunkSize = buffer.readUInt32LE(offset + 4);
+
+      if (chunkType === 'VP8 ' || chunkType === 'VP8L') {
+        // 简化处理，返回默认尺寸
+        return { width: 100, height: 100 };
+      }
+
+      offset += 8 + chunkSize;
+    }
+  } catch {
+    // 忽略错误
+  }
+
+  return { width: 100, height: 100 };
+}

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -548,6 +548,7 @@ export const useAppStore = create<AppStore>()(
         const attachments = [];
         // Handle pasted images
         if (message && Object.keys(pastedImageMap).length > 0) {
+          // 匹配旧格式: [Image #1]
           const pastedImageRegex = /\[Image (#\d+)\]/g;
           const imageMatches = [...message.matchAll(pastedImageRegex)];
 

--- a/src/ui/useInputHandlers.ts
+++ b/src/ui/useInputHandlers.ts
@@ -126,7 +126,6 @@ export function useInputHandlers() {
       fileSuggestion,
       inputState,
       togglePlanMode,
-      setForceTabTrigger,
       applyFileSuggestion,
       canTriggerTabSuggestion,
     ],
@@ -182,6 +181,7 @@ export function useInputHandlers() {
     history,
     historyIndex,
     setDraftInput,
+    setHistoryIndex,
     slashCommands,
     fileSuggestion,
     clearQueue,
@@ -202,7 +202,7 @@ export function useInputHandlers() {
     }
     // 2. history
     if (historyIndex !== null) {
-      let value;
+      let value: string;
       if (historyIndex === history.length - 1) {
         setHistoryIndex(null);
         value = draftInput;
@@ -239,8 +239,8 @@ export function useInputHandlers() {
   );
 
   const handleImagePaste = useCallback(
-    async (base64Data: string) => {
-      const result = await imageManager.handleImagePaste(base64Data);
+    async (base64Data: string, filename?: string) => {
+      const result = await imageManager.handleImagePaste(base64Data, filename);
       if (result.success && result.prompt) {
         return { prompt: result.prompt };
       }


### PR DESCRIPTION
图片占位符从 `[Image #1]` 改为 `[Image 100X100 filename]` 格式，综合参考了 codex 和 gemini。

<img width="757" height="490" alt="图片" src="https://github.com/user-attachments/assets/3d002daf-e18f-4142-8086-0bda9e9a514b" />

<img width="692" height="475" alt="图片" src="https://github.com/user-attachments/assets/a61ead3e-0275-41ab-9f27-5329aa2ab045" />

<img width="975" height="162" alt="图片" src="https://github.com/user-attachments/assets/422881e7-ff0d-4c03-8e18-e9ed2f43d0b9" />

