### PR TITLE
fix: browser integration mcp  cannot find module

### DIFF
--- a/scripts/bundleMcps.ts
+++ b/scripts/bundleMcps.ts
@@ -11,7 +11,7 @@ function log(message: string) {
 
 async function bundleMcp(fileName: string): Promise<boolean> {
   try {
-    const baseName = fileName.replace(/\.ts$/, '');
+    const baseName = fileName.replace(/\.mjs$/, '');
     const inputPath = join(MCPS_DIR, fileName);
     const outputPath = join(DIST_DIR, `${baseName}.mjs`);
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,10 +1,13 @@
-import { join } from 'pathe';
+import { join, dirname } from 'pathe';
 import { isLocal } from './utils/isLocal';
 import type { McpServerConfig } from './config';
+import { fileURLToPath } from 'url';
 
 export type BrowserConfig = {
   browser: boolean;
 };
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function getChromeDevToolsMcpServerConfig(): Record<
   string,


### PR DESCRIPTION
修复 browser integration mcp  加载失败