### PR TITLE
feat: add ctrl-g external editor support for prompt editing

### DIFF
--- a/src/ui/ChatInput.tsx
+++ b/src/ui/ChatInput.tsx
@@ -8,6 +8,7 @@ import { StatusLine } from './StatusLine';
 import { Suggestion, SuggestionItem } from './Suggestion';
 import { useAppStore } from './store';
 import TextInput from './TextInput';
+import { useExternalEditor } from './useExternalEditor';
 import { useInputHandlers } from './useInputHandlers';
 import { useTerminalSize } from './useTerminalSize';
 import { useTryTips } from './useTryTips';
@@ -29,6 +30,11 @@ export function ChatInput() {
     setStatus,
   } = useAppStore();
   const { columns } = useTerminalSize();
+  const { handleExternalEdit } = useExternalEditor({
+    value: inputState.state.value,
+    onChange: inputState.setValue,
+    setCursorPosition: inputState.setCursorPosition,
+  });
   const showSuggestions =
     slashCommands.suggestions.length > 0 ||
     fileSuggestion.matchedPaths.length > 0;
@@ -175,6 +181,7 @@ export function ChatInput() {
           disableCursorMovementForUpDownKeys={showSuggestions}
           onTabPress={handlers.handleTabPress}
           onDelete={handleDelete}
+          onExternalEdit={handleExternalEdit}
           columns={columns - 6}
           isDimmed={false}
         />

--- a/src/ui/TextInput/hooks/useTextInput.ts
+++ b/src/ui/TextInput/hooks/useTextInput.ts
@@ -45,6 +45,7 @@ type UseTextInputProps = {
   externalOffset: number;
   onOffsetChange: (offset: number) => void;
   onTabPress?: (isShiftTab: boolean) => void;
+  onExternalEdit?: () => void;
 };
 
 type UseTextInputResult = {
@@ -75,6 +76,7 @@ export function useTextInput({
   externalOffset,
   onOffsetChange,
   onTabPress,
+  onExternalEdit,
 }: UseTextInputProps): UseTextInputResult {
   const offset = externalOffset;
   const setOffset = onOffsetChange;
@@ -202,6 +204,13 @@ export function useTextInput({
     ['d', handleCtrlD],
     ['e', () => cursor.endOfLine()],
     ['f', () => cursor.right()],
+    [
+      'g',
+      () => {
+        onExternalEdit?.();
+        return cursor;
+      },
+    ],
     ['h', () => cursor.backspace()],
     ['k', () => cursor.deleteToLineEnd()],
     ['l', () => clear()],

--- a/src/ui/TextInput/index.tsx
+++ b/src/ui/TextInput/index.tsx
@@ -146,6 +146,11 @@ export type Props = {
    * Function to call when `Delete` or `Backspace` is pressed.
    */
   readonly onDelete?: () => void;
+
+  /**
+   * Optional callback when Ctrl+G is pressed to edit prompt in external editor.
+   */
+  readonly onExternalEdit?: () => void;
 };
 
 export default function TextInput({
@@ -174,6 +179,7 @@ export default function TextInput({
   onChangeCursorOffset,
   onTabPress,
   onDelete,
+  onExternalEdit,
 }: Props): React.JSX.Element {
   const { onInput, renderedValue } = useTextInput({
     value: originalValue,
@@ -199,6 +205,7 @@ export default function TextInput({
     externalOffset: cursorOffset,
     onOffsetChange: onChangeCursorOffset,
     onTabPress,
+    onExternalEdit,
   });
 
   // Enhanced paste detection state for multi-chunk text merging

--- a/src/ui/useExternalEditor.ts
+++ b/src/ui/useExternalEditor.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { openExternalEditor } from '../utils/externalEditor';
+
+type UseExternalEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  setCursorPosition: (position: number) => void;
+};
+
+type UseExternalEditorResult = {
+  handleExternalEdit: () => Promise<void>;
+};
+
+/**
+ * Hook to handle external editor integration
+ * Opens the current input value in an external editor and updates it with the result
+ */
+export function useExternalEditor({
+  value,
+  onChange,
+  setCursorPosition,
+}: UseExternalEditorProps): UseExternalEditorResult {
+  const handleExternalEdit = useCallback(async () => {
+    const result = await openExternalEditor(value);
+    if (result !== null && result !== value) {
+      onChange(result);
+      setCursorPosition(result.length);
+    }
+  }, [value, onChange, setCursorPosition]);
+
+  return { handleExternalEdit };
+}

--- a/src/utils/externalEditor.ts
+++ b/src/utils/externalEditor.ts
@@ -1,0 +1,164 @@
+import { execSync, spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Generate a unique temporary file path
+ * @param prefix - Filename prefix (default: "takumi-prompt")
+ * @param extension - File extension (default: ".md")
+ * @returns Full path to temporary file
+ */
+function getTempFilePath(
+  prefix: string = 'takumi-prompt',
+  extension: string = '.md',
+): string {
+  const timestamp = Date.now();
+  return path.join(os.tmpdir(), `${prefix}-${timestamp}${extension}`);
+}
+
+/**
+ * Check if a command exists in PATH
+ * @param command - Command to check
+ * @returns true if command exists, false otherwise
+ */
+function commandExists(command: string): boolean {
+  try {
+    const result =
+      process.platform === 'win32'
+        ? execSync(`where ${command}`, { stdio: 'pipe' })
+        : execSync(`command -v ${command}`, { stdio: 'pipe' });
+    return result.toString().trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the editor command to use
+ * Priority:
+ * 1. $VISUAL environment variable
+ * 2. $EDITOR environment variable
+ * 3. On Windows: start /wait notepad
+ * 4. On Unix: First available from code, vi, nano
+ * @returns Editor command or null if none found
+ */
+function getEditorCommand(): string | null {
+  // Check environment variables
+  if (process.env.VISUAL?.trim()) {
+    return process.env.VISUAL.trim();
+  }
+  if (process.env.EDITOR?.trim()) {
+    return process.env.EDITOR.trim();
+  }
+
+  // Platform-specific defaults
+  if (process.platform === 'win32') {
+    return 'start /wait notepad';
+  }
+
+  // Try common editors on Unix-like systems
+  const candidates = ['code', 'vi', 'nano'];
+  for (const editor of candidates) {
+    if (commandExists(editor)) {
+      return editor;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Clear the screen and prepare for external editor
+ * @returns Promise that resolves when screen is cleared
+ */
+function clearScreen(): Promise<void> {
+  return new Promise((resolve) => {
+    // Clear screen, reset attributes, show cursor
+    process.stdout.write('\x1B[0m\x1B[?25h\x1B[2J\x1B[H', () => {
+      resolve();
+    });
+  });
+}
+
+/**
+ * Open an external editor with the given text
+ * @param text - Initial text to edit
+ * @returns Modified text or null if cancelled/error
+ */
+export async function openExternalEditor(text: string): Promise<string | null> {
+  const tempFilePath = getTempFilePath();
+
+  try {
+    // Write current text to temporary file
+    fs.writeFileSync(tempFilePath, text, { encoding: 'utf-8', flag: 'w' });
+
+    // Get editor command
+    const editorCommand = getEditorCommand();
+    if (!editorCommand) {
+      return null;
+    }
+
+    // Prepare command with proper flags
+    let command = editorCommand;
+    if (editorCommand === 'code') {
+      command = 'code -w'; // -w flag waits for window to close
+    }
+
+    // Switch to alternate screen buffer
+    process.stdout.write('\x1B[?1049h');
+
+    // Clear screen
+    await clearScreen();
+
+    // Launch editor and wait for it to close
+    spawnSync(`${command} "${tempFilePath}"`, {
+      stdio: 'inherit',
+      shell: true,
+    });
+
+    // Restore original screen buffer
+    process.stdout.write('\x1B[?1049l');
+
+    // Read modified content
+    let modifiedText = fs.readFileSync(tempFilePath, { encoding: 'utf-8' });
+
+    // Remove single trailing newline if present (but not double newlines)
+    if (modifiedText.endsWith('\n') && !modifiedText.endsWith('\n\n')) {
+      modifiedText = modifiedText.slice(0, -1);
+    }
+
+    return modifiedText;
+  } catch (error) {
+    // Ensure we restore the screen even on error
+    try {
+      process.stdout.write('\x1B[?1049l');
+    } catch {
+      // Ignore restoration errors
+    }
+    return null;
+  } finally {
+    // Clean up temporary file
+    try {
+      if (fs.existsSync(tempFilePath)) {
+        fs.unlinkSync(tempFilePath);
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Get a human-readable name for the editor
+ * @returns Editor name for display
+ */
+export function getEditorName(): string {
+  const command = getEditorCommand();
+  if (!command) {
+    return 'editor';
+  }
+  // Extract first word of command (the actual editor name)
+  const editorName = command.split(' ')[0];
+  return editorName || 'editor';
+}


### PR DESCRIPTION
Add ability to open prompts in external editor using ctrl-g keyboard shortcut. This allows users to edit longer prompts in their preferred editor (VS Code, vim, nano, etc.).

- Add openExternalEditor utility with proper screen buffer management
- Add useExternalEditor React hook for state management
- Integrate ctrl-g handler in TextInput component
- Support $VISUAL and $EDITOR environment variables
- Fix focus reporting issue by avoiding bracketed paste manipulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)