### PR TITLE
fix: Update environment variable for volcengine

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1138,7 +1138,7 @@ export const providers: ProvidersMap = {
   },
   volcengine: {
     id: 'volcengine',
-    env: ['VOLCENGINE_API_KEY'],
+    env: ['ARK_API_KEY'],
     name: 'VolcEngine',
     api: 'https://ark.cn-beijing.volces.com/api/v3/chat/completions',
     doc: 'https://www.volcengine.com/docs/82379/1330310',


### PR DESCRIPTION
官方示例里是 export ARK_API_KEY="YOUR_API_KEY"，改成一致会不会好点。
<img width="333" height="152" alt="image" src="https://github.com/user-attachments/assets/0f736ee9-ffb0-48bc-abdb-e96ea49120f4" />
