### PR TITLE
feat: outputStyle glob supports symbolic links

### DIFF
--- a/src/outputStyle.ts
+++ b/src/outputStyle.ts
@@ -187,7 +187,7 @@ export function loadPolishedMarkdownFiles(
   }
   const files = glob.sync('**/*.md', {
     cwd: dir,
-    follow: true, // 支持软连接
+    follow: true,
   });
   return files.map((relativePath) => {
     const absPath = path.join(dir, relativePath);


### PR DESCRIPTION
对于配置文件，支持软连接指向的目录