### PR TITLE
fix: 修复 Windows 下路径分隔符导致的图片读取失败

### DIFF
--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -50,8 +50,9 @@ async function processImage(
     const ext = path.extname(filePath).toLowerCase();
 
     // Security: Validate file path to prevent traversal attacks
-    const resolvedPath = path.resolve(filePath);
-    if (!resolvedPath.startsWith(cwd)) {
+    const resolvedPath = path.normalize(path.resolve(filePath));
+    const resolvedCwd = path.normalize(path.resolve(process.cwd()));
+    if (!resolvedPath.startsWith(resolvedCwd)) {
       throw new Error('Invalid file path: path traversal detected');
     }
 


### PR DESCRIPTION
# 问题描述
在 Windows 系统上读取图片文件时，会错误地抛出 "path traversal detected" 错误，即使文件在工作区目录内也无法读取。
# 问题原因
Windows 下 process.cwd() 返回反斜杠路径（如 C:\project），而 path.resolve() 返回正斜杠路径（如 C:/project/images/pic.png），导致字符串比较失败：

```
// 修复前
const resolvedPath = path.resolve(filePath);  // "C:/project/images/pic.png"
if (!resolvedPath.startsWith(process.cwd())) { // "C:\project"
  throw new Error('Invalid file path: path traversal detected');
}
// ❌ 比较失败: "C:/..." 不是以 "C:\..." 开头
```

# 失败截图
<img width="301" height="53" alt="image" src="https://github.com/user-attachments/assets/09d9726b-d653-4feb-adec-ba823283e9e0" />

# 修复后，成功截图
<img width="250" height="56" alt="image" src="https://github.com/user-attachments/assets/63e9fd91-e1cc-4cf4-85b3-54f2aff2a367" />
