### PR TITLE
feat: add language switching support to spec commands 

### DIFF
--- a/src/slash-commands/builtin/index.ts
+++ b/src/slash-commands/builtin/index.ts
@@ -21,6 +21,7 @@ import { createTerminalSetupCommand } from './terminal-setup';
 export function createBuiltinCommands(opts: {
   productName: string;
   argvConfig: Record<string, any>;
+  language: string;
 }): SlashCommand[] {
   return [
     clearCommand,
@@ -38,8 +39,8 @@ export function createBuiltinCommands(opts: {
     createBugCommand(),
     compactCommand,
     statusCommand,
-    brainstormCommand,
-    writePlanCommand,
-    executePlanCommand,
+    brainstormCommand(opts.language),
+    writePlanCommand(opts.language),
+    executePlanCommand(opts.language),
   ];
 }

--- a/src/slash-commands/builtin/spec/brainstorm.ts
+++ b/src/slash-commands/builtin/spec/brainstorm.ts
@@ -1,16 +1,17 @@
 import type { PromptCommand } from '../../types';
 
-export const brainstormCommand = {
-  type: 'prompt',
-  name: 'spec:brainstorm',
-  description:
-    'Transform rough ideas into fully-formed designs through structured questioning',
-  progressMessage: 'Refining your idea into a design...',
-  async getPromptForCommand(args: string) {
-    return [
-      {
-        role: 'user',
-        content: `
+export function brainstormCommand(language: string): PromptCommand {
+  return {
+    type: 'prompt',
+    name: 'spec:brainstorm',
+    description:
+      'Transform rough ideas into fully-formed designs through structured questioning',
+    progressMessage: 'Refining your idea into a design...',
+    async getPromptForCommand(args: string) {
+      return [
+        {
+          role: 'user',
+          content: `
 # Brainstorming Ideas Into Designs
 
 ## Overview
@@ -20,6 +21,8 @@ Transform rough ideas into fully-formed designs through structured questioning a
 **Core principle:** Ask questions to understand, explore alternatives, present design incrementally for validation.
 
 **Announce at start:** "I'm refining your idea into a design."
+
+**Language:** Please communicate in ${language}.
 
 ## The Process
 
@@ -59,7 +62,8 @@ Transform rough ideas into fully-formed designs through structured questioning a
 
 Arguments: ${args}
         `.trim(),
-      },
-    ];
-  },
-} as PromptCommand;
+        },
+      ];
+    },
+  } as PromptCommand;
+}

--- a/src/slash-commands/builtin/spec/execute-plan.ts
+++ b/src/slash-commands/builtin/spec/execute-plan.ts
@@ -1,15 +1,16 @@
 import type { PromptCommand } from '../../types';
 
-export const executePlanCommand = {
-  type: 'prompt',
-  name: 'spec:execute-plan',
-  description: 'Execute detailed plans in batches with review checkpoints',
-  progressMessage: 'Executing implementation plan...',
-  async getPromptForCommand(args: string) {
-    return [
-      {
-        role: 'user',
-        content: `
+export function executePlanCommand(language: string): PromptCommand {
+  return {
+    type: 'prompt',
+    name: 'spec:execute-plan',
+    description: 'Execute detailed plans in batches with review checkpoints',
+    progressMessage: 'Executing implementation plan...',
+    async getPromptForCommand(args: string) {
+      return [
+        {
+          role: 'user',
+          content: `
 # Executing Plans
 
 ## Overview
@@ -19,6 +20,8 @@ Load plan, review critically, execute tasks in batches, report for review betwee
 **Core principle:** Batch execution with checkpoints for architect review.
 
 **Announce at start:** "I'm implementing this plan."
+
+**Language:** Please communicate in ${language}.
 
 ## The Process
 
@@ -81,7 +84,8 @@ After all tasks complete and verified:
 
 Arguments: ${args}
         `.trim(),
-      },
-    ];
-  },
-} as PromptCommand;
+        },
+      ];
+    },
+  } as PromptCommand;
+}

--- a/src/slash-commands/builtin/spec/write-plan.ts
+++ b/src/slash-commands/builtin/spec/write-plan.ts
@@ -1,16 +1,17 @@
 import type { PromptCommand } from '../../types';
 
-export const writePlanCommand = {
-  type: 'prompt',
-  name: 'spec:write-plan',
-  description:
-    'Create detailed implementation plans with bite-sized tasks for engineers with zero codebase context',
-  progressMessage: 'Creating implementation plan...',
-  async getPromptForCommand(args: string) {
-    return [
-      {
-        role: 'user',
-        content: `
+export function writePlanCommand(language: string): PromptCommand {
+  return {
+    type: 'prompt',
+    name: 'spec:write-plan',
+    description:
+      'Create detailed implementation plans with bite-sized tasks for engineers with zero codebase context',
+    progressMessage: 'Creating implementation plan...',
+    async getPromptForCommand(args: string) {
+      return [
+        {
+          role: 'user',
+          content: `
 # Writing Plans
 
 ## Overview
@@ -20,6 +21,8 @@ Write comprehensive implementation plans assuming the engineer has zero context 
 Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
 
 **Announce at start:** "I'm creating the implementation plan."
+
+**Language:** Please communicate in ${language}.
 
 **Save plans to:** \`docs/plans/YYYY-MM-DD-\<feature-name\>.md\`
 
@@ -91,7 +94,8 @@ Expected: PASS
 
 Arguments: ${args}
         `.trim(),
-      },
-    ];
-  },
-} as PromptCommand;
+        },
+      ];
+    },
+  } as PromptCommand;
+}

--- a/src/slashCommand.ts
+++ b/src/slashCommand.ts
@@ -18,6 +18,7 @@ export type SlashCommandManagerOpts = {
   productName: string;
   slashCommands: SlashCommand[];
   argvConfig: Record<string, any>;
+  language: string;
 };
 
 export type CommandEntry = {
@@ -34,6 +35,7 @@ export class SlashCommandManager {
     const builtin = createBuiltinCommands({
       productName,
       argvConfig: opts.argvConfig,
+      language: opts.language,
     });
     builtin.forEach((command) => {
       commands.set(command.name, { command, source: CommandSource.Builtin });
@@ -71,6 +73,7 @@ export class SlashCommandManager {
       paths: context.paths,
       slashCommands: pluginSlashCommands,
       argvConfig: context.argvConfig,
+      language: context.config.language,
     });
   }
 


### PR DESCRIPTION
Resolves #404

- Pass language config from context to createBuiltinCommands
- Update all three spec commands (brainstorm, write-plan, execute-plan) to accept and use language parameter
- Add language instruction to prompts: "Please communicate in ${language}"
- Convert spec commands from const exports to factory functions

The spec commands now respect the user's language preference from config instead of always defaulting to English output.