### PR TITLE
feat: add language switching support to review command 

### DIFF
--- a/src/slash-commands/builtin/index.ts
+++ b/src/slash-commands/builtin/index.ts
@@ -34,7 +34,7 @@ export function createBuiltinCommands(opts: {
     createModelCommand(opts),
     createOutputStyleCommand(),
     createResumeCommand(),
-    createReviewCommand(),
+    createReviewCommand(opts.language),
     createTerminalSetupCommand(),
     createBugCommand(),
     compactCommand,

--- a/src/slash-commands/builtin/review.ts
+++ b/src/slash-commands/builtin/review.ts
@@ -1,6 +1,6 @@
 import type { PromptCommand } from '../types';
 
-export function createReviewCommand() {
+export function createReviewCommand(language: string) {
   return {
     type: 'prompt',
     name: 'review',
@@ -20,7 +20,9 @@ export function createReviewCommand() {
       return [
         {
           role: 'user',
-          content: `You are an expert code reviewer. Follow these steps:
+          content: `You are an expert code reviewer. Please communicate in ${language}.
+
+Follow these steps:
 
 1. If no PR number is provided in the args, use bash("git --no-pager diff --cached -- . ${lockFilesPattern}") to get the diff
 2. If a PR number is provided, use bash("gh pr diff <number>") to get the diff


### PR DESCRIPTION
Following the pattern established in PR #405, this commit adds language support to the /review slash command. The review command now respects the user's language preference from config instead of always defaulting to English output.

Changes:
- Modified createReviewCommand() to accept language parameter
- Added language instruction to review prompt
- Updated command registration to pass opts.language

Ref: #405