### PR TITLE
fix(browser): width exceeds and horizontal scrollbar appears

### DIFF
--- a/browser/src/components/Sider/Conversations.tsx
+++ b/browser/src/components/Sider/Conversations.tsx
@@ -20,6 +20,7 @@ const useStyle = createStyles(({ token, css }) => {
 
       .ant-conversations {
         padding: 0;
+        overflow: hidden;
 
         .ant-conversations-group {
           margin-bottom: 16px;


### PR DESCRIPTION
Width exceeds and horizontal scrollbar appears

<img width="738" height="298" alt="image" src="https://github.com/user-attachments/assets/a68c9e73-ad0d-43ee-97ad-8df9e6d9fd76" />
