### PR TITLE
fix: reset selected index when suggestions change

### DIFF
--- a/src/ui/useSlashCommands.ts
+++ b/src/ui/useSlashCommands.ts
@@ -41,7 +41,7 @@ export function useSlashCommands(input: string) {
 
   useEffect(() => {
     setSelectedIndex(0);
-  }, []);
+  }, [suggestions]);
 
   const navigateNext = () => {
     if (suggestions.length === 0) return;


### PR DESCRIPTION
# Description
There is a highlight issue in the Terminal CLI suggestions list. 

# Step
1. input '/i'
2. click down arrow key several times
3. input '/br'
4. the first item in the suggestions list is not being highlighted

# Reason
The selected index is not refreshed after the suggestions list is changed.

# Issue snapshot
<img width="961" height="407" alt="image" src="https://github.com/user-attachments/assets/16876cda-6d3f-47ea-b60a-b8507e8d3140" />

