### PR TITLE
fix(mcp): fix redundant console output for stdio-type MCP

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -338,6 +338,7 @@ export class MCPManager {
         transport: new Experimental_StdioMCPTransport({
           command: config.command,
           args: config.args,
+          stderr: 'ignore',
           env,
         }),
       });


### PR DESCRIPTION
忽略stderr输出流

在MCP管理器中配置stdio传输时，添加了忽略stderr的选项，以避免不必要的输出干扰主进程。

<img width="1409" height="576" alt="image" src="https://github.com/user-attachments/assets/b425e832-279e-45ca-855e-300a9b3ea98b" />
