### PR TITLE
feat: add visionModel support for multimodal tasks

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -24,6 +24,7 @@ Available Configuration Keys:
   model                                 Primary model for AI interactions (default: flash)
   smallModel                            Smaller model for lightweight operations
   planModel                             Model for planning operations
+  visionModel                           Model for image/vision tasks
   language                              Language for AI responses (default: English)
   quiet                                 Suppress verbose output (boolean, default: false)
   approvalMode                          Approval mode for operations (default|autoEdit|yolo, default: default)

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export type Config = {
   model: string;
   planModel: string;
   smallModel?: string;
+  visionModel?: string;
   language: string;
   quiet: boolean;
   approvalMode: ApprovalMode;
@@ -84,6 +85,7 @@ const VALID_CONFIG_KEYS = [
   'model',
   'planModel',
   'smallModel',
+  'visionModel',
   'systemPrompt',
   'todo',
   'autoCompact',
@@ -145,6 +147,7 @@ export class ConfigManager {
     ) as Config;
     config.planModel = config.planModel || config.model;
     config.smallModel = config.smallModel || config.model;
+    config.visionModel = config.visionModel || config.model;
     if (config.browser) {
       config.mcpServers = mergeBrowserMcpServers(
         config.mcpServers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ type Argv = {
   outputStyle?: string;
   planModel?: string;
   smallModel?: string;
+  visionModel?: string;
   resume?: string;
   systemPrompt?: string;
   // array
@@ -87,6 +88,7 @@ async function parseArgs(argv: any) {
       'outputStyle',
       'planModel',
       'smallModel',
+      'visionModel',
       'resume',
       'systemPrompt',
     ],
@@ -116,6 +118,7 @@ Options:
   -m, --model <model>           Specify model to use
   --plan-model <model>          Specify a plan model for some tasks
   --small-model <model>         Specify a small model for quick operations
+  --vision-model <model>        Specify a vision model for image tasks
   -r, --resume <session-id>     Resume a session
   -c, --continue                Continue the latest session
   -q, --quiet                   Quiet mode, non interactive
@@ -297,6 +300,7 @@ export async function runNeovate(opts: {
       model: argv.model,
       planModel: argv.planModel,
       smallModel: argv.smallModel,
+      visionModel: argv.visionModel,
       quiet: argv.quiet,
       outputFormat: argv.outputFormat,
       plugins: argv.plugin,


### PR DESCRIPTION
Close #362

# 为多模态任务添加 visionModel 支持

## What / 功能说明

Added `visionModel` configuration to support dedicated models for image/video tasks, similar to how `planModel` works for planning operations.

新增 `visionModel` 配置项，支持为图片/视频等多模态任务指定专用模型，设计理念与 `planModel` 一致。

## Why / 背景

Currently Neovate only allows configuring `model` and `planModel`, but there's no way to specify a separate model for multimodal tasks (images, videos, etc.).

当前 Neovate 只能配置主模型（`model`）和规划模型（`planModel`），无法为图片、音频等多模态任务单独指定模型。

## How / 实现方式

### Automatic Switching / 自动切换

When conversation history contains images, the system automatically uses `visionModel` if:

- `visionModel` is configured
- `visionModel` differs from the base `model`
- User hasn't explicitly specified a model via `opts.model`

当对话历史包含图片时，系统会自动使用 `visionModel`，前提是：

- 已配置 `visionModel`
- `visionModel` 与基础 `model` 不同
- 用户未通过 `opts.model` 明确指定模型

### Model Selection Priority / 模型选择优先级

```
1. opts.model (explicitly specified) → highest priority
   opts.model（明确指定）→ 最高优先级

2. visionModel (when images detected)
   visionModel（检测到图片时）

3. default model (from config)
   默认模型（来自配置）
```

## Changes / 修改内容

- `src/config.ts` - Added `visionModel` field to Config type / 添加 `visionModel` 配置字段
- `src/project.ts` - Implemented image detection and auto-switching logic / 实现图片检测和自动切换逻辑
- `src/index.ts` - Added `--vision-model` CLI argument / 添加 CLI 参数支持
- `src/commands/config.ts` - Updated help text / 更新帮助文本

## Breaking Changes / 破坏性变更

None. Backward compatible - if `visionModel` is not configured, it falls back to the base `model`.

无。向后兼容 - 如果未配置 `visionModel`，会自动回退到基础 `model`。



