### PR TITLE
fix: log warning instead of throwing error when no changes to commit

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -198,7 +198,8 @@ export async function runCommit(context: Context) {
   }
 
   if (!hasChanged) {
-    throw new Error('No changes to commit');
+    logger.logWarn('No changes to commit');
+    return;
   }
 
   if (argv.stage) {
@@ -216,9 +217,10 @@ export async function runCommit(context: Context) {
 
   const diff = await getStagedDiff();
   if (diff.length === 0) {
-    throw new Error(
+    logger.logWarn(
       'No staged changes to commit. Use -s flag to stage all changes or manually stage files with git add.',
     );
+    return;
   }
 
   const fileList = await getStagedFileList();


### PR DESCRIPTION
修复前：

<img width="406" height="202" alt="图片" src="https://github.com/user-attachments/assets/4a468c34-d315-4129-8daa-9aaffce2b2c0" />

修复后：

<img width="346" height="94" alt="图片" src="https://github.com/user-attachments/assets/022b434d-6f51-48a7-8c0b-56d15c098f00" />

