### PR TITLE
feat: add platform-specific keyboard shortcuts for queued messages

### DIFF
--- a/src/ui/ChatInput.tsx
+++ b/src/ui/ChatInput.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from 'ink';
 import { useCallback, useMemo } from 'react';
+import os from 'os';
 import { SPACING, UI_COLORS } from './constants';
 import { DebugRandomNumber } from './Debug';
 import { MemoryModal } from './MemoryModal';
@@ -23,6 +24,12 @@ export function ChatInput() {
     reverseSearch,
   } = useInputHandlers();
   const { currentTip } = useTryTips();
+
+  // Memoize platform-specific modifier key to avoid repeated os.platform() calls
+  const modifierKey = useMemo(
+    () => (os.platform() === 'darwin' ? 'option+up' : 'alt+up'),
+    [],
+  );
   const {
     log,
     setExitMessage,
@@ -64,7 +71,8 @@ export function ChatInput() {
       return reverseSearch.placeholderText;
     }
     if (queuedMessages.length > 0) {
-      return 'Press option+up to edit queued messages';
+      // Show platform-appropriate keyboard shortcut text
+      return `Press ${modifierKey} to edit queued messages`;
     }
     if (currentTip) {
       return currentTip;

--- a/src/ui/TextInput/index.tsx
+++ b/src/ui/TextInput/index.tsx
@@ -28,7 +28,7 @@ export type Props = {
   readonly onHistoryUp?: () => void;
 
   /**
-   * Optional callback for handling queued messages on option+up arrow
+   * Optional callback for handling queued messages on alt+up arrow (option+up on macOS)
    */
   readonly onQueuedMessagesUp?: () => void;
 


### PR DESCRIPTION
- Display option+up on macOS and alt+up on other platforms in ChatInput placeholder
- Update TextInput documentation to clarify platform-specific behavior
- Optimize performance by memoizing os.platform() call to avoid repeated system calls
- Improves cross-platform user experience with accurate keyboard shortcuts