### PR TITLE
fix(outputStyle): process header lines starting with # and limit description length

### DIFF
--- a/src/outputStyle.ts
+++ b/src/outputStyle.ts
@@ -227,8 +227,20 @@ function loadPolishedMarkdownFile(
   if (!description) {
     const lines = file.body.split('\n');
     const firstLine = lines.find((line) => line.trim())?.trim();
-    if (firstLine && /^[a-zA-Z]/.test(firstLine)) {
-      description = firstLine;
+    if (firstLine) {
+      // Handle title lines starting with # (supports multiple #)
+      if (firstLine.startsWith('#')) {
+        // Remove all # symbols and clean up
+        description = firstLine.replace(/^#+\s*/, '').trim();
+      } else {
+        // Use directly for any other starting character (including ```, ##, *, -, etc.)
+        description = firstLine;
+      }
+
+      // Limit length to 50 characters, truncate and add ellipsis if exceeds
+      if (description.length > 50) {
+        description = `${description.substring(0, 50)}...`;
+      }
     }
   }
   if (!description) {


### PR DESCRIPTION
当文件描述为空时，现在能正确处理以#开头的标题行，移除#符号并清理空格。同时添加了描述长度限制，超过50字符时自动截断并添加省略号，使自动读取描述的逻辑跟claude code完全一致