### PR TITLE
refactor(llmsContext): export getTerminal and add platform info display

### DIFF
--- a/src/llmsContext.ts
+++ b/src/llmsContext.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'pathe';
-import { platform } from 'process';
 import type { Context } from './context';
 import { PluginHookType } from './plugin';
 import { getLlmsRules } from './rules';
 import { createLSTool } from './tools/ls';
+import { getTerminal } from './utils/env';
 import { getGitStatus, getLlmGitStatus } from './utils/git';
 import { isProjectDirectory } from './utils/project';
 
@@ -89,7 +89,16 @@ ${Object.entries(llmsContext)
             opts.additionalDirectories.join(', '),
         }),
       'Is directory a git repo': gitStatus ? 'YES' : 'NO',
-      Platform: platform,
+      Platform:
+        process.platform === 'win32'
+          ? 'windows'
+          : process.platform === 'darwin'
+            ? 'macos'
+            : 'linux',
+      Terminal: getTerminal() || 'unknown',
+      Shell: process.platform === 'win32' ? 'PowerShell' : 'Bash',
+      'Node Version': process.version,
+      Architecture: process.arch,
       "Today's date": new Date().toLocaleDateString(),
     };
     llmsEnv = await opts.context.apply({

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,4 @@
-function getTerminal() {
+export function getTerminal() {
   if (process.env.CURSOR_TRACE_ID) return 'cursor';
   if (process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('/.cursor-server/bin/'))
     return 'cursor';


### PR DESCRIPTION
从 utils/env.ts 导出 getTerminal 函数。在 llmsContext 中添加终端 shell Node 版本和架构信息以增强诊断能力。

目前的llmsContext，缺少Shell信息，在Windows下会让大模型多次尝试bash，多次失败后才切换cmd或者powershell，所以增加了额外环境信息