### PR TITLE
feat: add providers configuration for enabling/disabling specific pro…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,11 @@ export type Config = {
    * Key is the tool name, value is boolean (false to disable).
    */
   tools?: Record<string, boolean>;
+  /**
+   * Providers configuration for enabling/disabling specific providers.
+   * Key is the provider ID, value is boolean (false to disable).
+   */
+  providers?: Record<string, boolean>;
 };
 
 const DEFAULT_CONFIG: Partial<Config> = {
@@ -100,6 +105,7 @@ const DEFAULT_CONFIG: Partial<Config> = {
   browser: false,
   extensions: {},
   tools: {},
+  providers: {},
   desktop: {
     theme: 'light',
     sendMessageWith: 'enter',
@@ -123,6 +129,7 @@ const VALID_CONFIG_KEYS = [
   'httpProxy',
   'extensions',
   'tools',
+  'providers',
 ];
 const ARRAY_CONFIG_KEYS = ['plugins'];
 const OBJECT_CONFIG_KEYS = [
@@ -131,6 +138,7 @@ const OBJECT_CONFIG_KEYS = [
   'provider',
   'extensions',
   'tools',
+  'providers',
   'desktop',
 ];
 const BOOLEAN_CONFIG_KEYS = [

--- a/src/model.ts
+++ b/src/model.ts
@@ -1816,6 +1816,17 @@ export async function resolveModelWithContext(
     );
   }
 
+  // Filter out disabled providers based on configuration
+  if (context.config.providers) {
+    finalProviders = Object.fromEntries(
+      Object.entries(finalProviders).filter(([providerId, provider]) => {
+        // If provider is explicitly disabled in config, filter it out
+        const isDisabled = context.config.providers![providerId] === false;
+        return !isDisabled;
+      }),
+    );
+  }
+
   const hookedModelAlias = await context.apply({
     hook: 'modelAlias',
     args: [],


### PR DESCRIPTION
…viders

Add new 'providers' configuration option to allow users to enable or disable specific AI providers through configuration. This improves the model selection experience by allowing users to hide unused providers, making the interface cleaner and more focused on their preferred providers.

* Add providers field to Config type definition
* Implement provider filtering logic in resolveModelWithContext
* Update configuration validation arrays to include providers option