### PR TITLE
refactor: unify GLM series model names to GLM-X.Y format

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -739,7 +739,7 @@ export const models: ModelMap = {
     limit: { context: 200000, output: 100000 },
   },
   'glm-4.5': {
-    name: 'GLM 4.5',
+    name: 'GLM-4.5',
     attachment: false,
     reasoning: true,
     temperature: true,
@@ -778,7 +778,7 @@ export const models: ModelMap = {
     limit: { context: 131072, output: 98304 },
   },
   'glm-4.5v': {
-    name: 'GLM 4.5V',
+    name: 'GLM-4.5V',
     attachment: true,
     reasoning: true,
     temperature: true,


### PR DESCRIPTION
- Update glm-4.5 model name from 'GLM 4.5' to 'GLM-4.5'
- Update glm-4.5v model name from 'GLM 4.5V' to 'GLM-4.5V'
- Ensures consistent naming convention across all GLM models

All GLM models now follow the standardized GLM-X.Y format:
- GLM-4.5, GLM-4.5-Air, GLM-4.5-Flash, GLM-4.5V, GLM-4.6