### PR TITLE
fix: handle 'Other' option state updates and improve input selection

### DIFF
--- a/src/ui/AskQuestionModal.tsx
+++ b/src/ui/AskQuestionModal.tsx
@@ -312,11 +312,32 @@ function QuestionView({
           { textInputValue: value },
           question.multiSelect ?? false,
         );
+
+        // Update answer if the "Other" option is currently selected
+        // We check current state to decide whether to update the final answer
+        const isSelected = question.multiSelect
+          ? Array.isArray(state?.selectedValue) &&
+            state?.selectedValue.includes('__other__')
+          : state?.selectedValue === '__other__';
+
+        if (isSelected) {
+          if (question.multiSelect) {
+            const values = Array.isArray(state?.selectedValue)
+              ? state!.selectedValue
+              : [];
+            const finalValues = values
+              .filter((v: string) => v !== '__other__')
+              .concat(value ? [value] : []);
+            onAnswer(questionText, finalValues, undefined, false);
+          } else {
+            onAnswer(questionText, '__other__', value);
+          }
+        }
       },
     };
 
     return [...predefinedOptions, otherOption];
-  }, [question, questionStates, onUpdateQuestionState]);
+  }, [question, questionStates, onUpdateQuestionState, onAnswer]);
 
   const questionText = question.question;
   const state = questionStates[questionText];

--- a/src/ui/SelectInput.tsx
+++ b/src/ui/SelectInput.tsx
@@ -144,7 +144,7 @@ export function SelectInput({
         // For input type options, show as regular option until selected
         const displayLabel =
           option.type === 'input'
-            ? option.placeholder || 'Type something.'
+            ? option.initialValue || option.placeholder || 'Type something.'
             : option.label;
 
         return (
@@ -182,10 +182,28 @@ export function SelectInput({
                     setFocusedInputValue(value);
                     option.onChange?.(value);
                     onFocus?.(option.value);
+
+                    // Auto-deselect if input becomes empty in multi-select mode
+                    if (mode === 'multi' && value.length === 0) {
+                      if (selectedValues.includes(option.value)) {
+                        const newValues = selectedValues.filter(
+                          (v) => v !== option.value,
+                        );
+                        setSelectedValues(newValues);
+                        onChange(newValues);
+                      }
+                    }
                   }}
                   onSubmit={() => {
                     if (mode === 'single') {
                       handleSingleSelect(selectedIndex);
+                    } else if (mode === 'multi') {
+                      if (!selectedValues.includes(option.value)) {
+                        const newValues = [...selectedValues, option.value];
+                        setSelectedValues(newValues);
+                        onChange(newValues);
+                      }
+                      onSubmit?.();
                     }
                   }}
                 />


### PR DESCRIPTION
Fixed state synchronization for 'Other' option in AskQuestionModal and improved input option selection behavior in SelectInput to ensure proper state updates when the 'Other' option is selected. 