### PR TITLE
fix: add defensive checks for diff generation

### DIFF
--- a/src/ui/DiffViewer.tsx
+++ b/src/ui/DiffViewer.tsx
@@ -34,6 +34,9 @@ function generateFileDiff(
   newContent: string,
   filePath: string,
 ): string {
+  // Defensive check: diff library crashes if input is not a string
+  if (typeof originalContent !== 'string') originalContent = '';
+  if (typeof newContent !== 'string') newContent = '';
   return createTwoFilesPatch(
     `${filePath} (original)`,
     `${filePath} (modified)`,

--- a/src/ui/Messages.tsx
+++ b/src/ui/Messages.tsx
@@ -589,11 +589,11 @@ function ToolResultItem({ part }: { part: ToolResultPart }) {
         const originalContentValue =
           typeof originalContent === 'string'
             ? originalContent
-            : input[originalContent.inputKey];
+            : (input[originalContent.inputKey] ?? '');
         const newContentValue =
           typeof newContent === 'string'
             ? newContent
-            : input[newContent.inputKey];
+            : (input[newContent.inputKey] ?? '');
         return (
           <DiffViewer
             originalContent={originalContentValue}


### PR DESCRIPTION
fix .split crash problem

e.g.
<img width="879" height="258" alt="image" src="https://github.com/user-attachments/assets/2b018193-ea52-43bd-87f7-a32cd7b1ba37" />

root cause:
<img width="1380" height="1466" alt="image" src="https://github.com/user-attachments/assets/237a8432-d310-4b83-a880-ad75d0d9b68b" />

