### PR TITLE
fix: remove svg from image extensions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,10 +9,7 @@ export const IMAGE_EXTENSIONS = new Set([
   '.jpg',
   '.jpeg',
   '.gif',
-  '.bmp',
   '.webp',
-  '.tiff',
-  '.tif',
 ]);
 export const CANCELED_MESSAGE_TEXT = '[Request interrupted by user]';
 


### PR DESCRIPTION
模型没法处理 svg 图片 "1 validation error detected: Value at 'messages.8.member.content.1.member.image.format' failed to satisfy constraint: Member must satisfy enum value set: [gif, jpeg, png, webp]"、参考 claude code 当前文本处理