### PR TITLE
fix: add space after checkbox symbol in todo items

### DIFF
--- a/src/ui/Todo.tsx
+++ b/src/ui/Todo.tsx
@@ -54,7 +54,7 @@ function TodoItem({
         <Text color={color} bold={isCurrent}>
           {todo.status === 'completed'
             ? symbols.checkboxOn
-            : symbols.checkboxOff}
+            : symbols.checkboxOff}{' '}
         </Text>
       </Box>
       <Box>


### PR DESCRIPTION
before:
<img width="562" height="539" alt="iTerm2 2025-12-26 09 12 33" src="https://github.com/user-attachments/assets/d1e39850-13e0-412a-a3ac-cd905956c914" />

after:
<img width="529" height="547" alt="iTerm2 2025-12-26 09 12 18" src="https://github.com/user-attachments/assets/f95d15ce-35b9-4026-9f4b-9c4760abc06c" />
