### PR TITLE
chore: remove neo binary alias from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "types": "./dist/index.d.ts",
   "source": "./src/index.ts",
   "bin": {
-    "neovate": "./dist/cli.mjs",
-    "neo": "./dist/cli.mjs"
+    "neovate": "./dist/cli.mjs"
   },
   "scripts": {
     "dev": "bun ./src/cli.ts",


### PR DESCRIPTION
it conflicts with neocoder (in ant group), which also has a neo bin. so when have neocoder installed, it will be failed to install @neovate/code.