### PR TITLE
feat: add command description field to bash tool

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -874,6 +874,22 @@ cd /foo/bar && pytest tests
         .describe(
           'Set to true to run this command in the background. Use bash_output to read output later.',
         ),
+      description: z
+        .string()
+        .optional()
+        .describe(`Clear, concise description of what this command does in 5-10 words, in active voice. Examples:
+Input: ls
+Output: List files in current directory
+
+Input: git status
+Output: Show working tree status
+
+Input: npm install
+Output: Install package dependencies
+
+Input: mkdir foo
+Output: Create directory 'foo'
+          `),
     }),
     getDescription: ({ params }) => {
       if (!params.command || typeof params.command !== 'string') {

--- a/src/ui/ApprovalModal.tsx
+++ b/src/ui/ApprovalModal.tsx
@@ -111,6 +111,11 @@ function ToolPreview({ toolUse, cwd }: ToolPreviewProps) {
         <Box marginLeft={2}>
           <Text>{params.command}</Text>
         </Box>
+        {params.description && (
+          <Box marginLeft={2}>
+            <Text color={UI_COLORS.ASK_SECONDARY}>{params.description}</Text>
+          </Box>
+        )}
       </Box>
     );
   }


### PR DESCRIPTION
<img width="1774" height="682" alt="image" src="https://github.com/user-attachments/assets/ae9dbc77-da75-4196-8046-95b1657f64de" />
bash tool 增加执行意图描述