### PR TITLE
fix: use dynamic column width for SelectInput text input

### DIFF
--- a/src/ui/ChatInput.tsx
+++ b/src/ui/ChatInput.tsx
@@ -226,7 +226,7 @@ export function ChatInput() {
               onTabPress={handlers.handleTabPress}
               onDelete={handleDelete}
               onExternalEdit={handleExternalEdit}
-              columns={columns - 6}
+              columns={{ useTerminalSize: true, prefix: 2, suffix: 4 }}
               isDimmed={false}
               onCtrlBBackground={
                 bashBackgroundPrompt ? handleMoveToBackground : undefined

--- a/src/ui/SelectInput.tsx
+++ b/src/ui/SelectInput.tsx
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import { symbols } from '../utils/symbols';
 import { UI_COLORS } from './constants';
 import TextInput from './TextInput';
-import { useTerminalSize } from './useTerminalSize';
 
 export type SelectOption = {
   type: 'text' | 'input';
@@ -36,12 +35,6 @@ export function SelectInput({
   onSubmit,
   submitButtonText = 'Submit',
 }: SelectInputProps) {
-  const { columns: terminalWidth } = useTerminalSize();
-  // Prefix width: "> N. " = 5 chars, or "> N. [ ] " = 9 chars for multi
-  // Max options is 5 (4 + "Other"), so always 1 digit
-  const prefixWidth = mode === 'multi' ? 9 : 5;
-  const inputColumns = terminalWidth - prefixWidth;
-
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [selectedValues, setSelectedValues] = useState<string[]>(
     mode === 'multi' && Array.isArray(defaultValue) ? defaultValue : [],
@@ -183,7 +176,11 @@ export function SelectInput({
                   </Text>
                 )}
                 <TextInput
-                  columns={inputColumns}
+                  columns={{
+                    useTerminalSize: true,
+                    // Prefix width: "> N. " = 5 chars, "> N. [ ] " = 9 chars for multi
+                    prefix: mode === 'multi' ? 9 : 5,
+                  }}
                   value={focusedInputValue || option.initialValue || ''}
                   placeholder={option.placeholder}
                   onChange={(value) => {


### PR DESCRIPTION
## Problem

When using the `AskUserQuestion` tool, the "Other" option allows users to type custom text via a `TextInput` component. The text input was rendered inline with the option prefix (e.g., `> 5. `), but there was no `columns` prop specified.

This caused issues with text display:
1. **Text truncation**: Long text was truncated with `...` due to `wrap="truncate-end"` in TextInput
2. **No width control**: The input did not know how much space was available for text

### Visual Example (Before)

```
> 5. i want make a snake game i want make a snake game i want make...
```

Text gets truncated with `...` instead of wrapping properly.

## Solution

Add dynamic column calculation based on terminal width:

1. **Use `useTerminalSize` hook** to get the current terminal width and listen for resize events
2. **Calculate prefix width** based on the mode:
   - Single select: `"> N. "` = 5 characters
   - Multi select: `"> N. [ ] "` = 9 characters
   - Note: Max options is 5 (4 predefined + "Other"), so index is always 1 digit
3. **Calculate available columns**: `terminalWidth - prefixWidth`
4. **Pass to TextInput**: The `columns` prop controls text wrapping width

### Code Changes

```tsx
const { columns: terminalWidth } = useTerminalSize();
const prefixWidth = mode === "multi" ? 9 : 5;
const inputColumns = terminalWidth - prefixWidth;

<TextInput columns={inputColumns} ... />
```

### Result

- Terminal 80 cols, single mode: `80 - 5 = 75` columns for input
- Terminal 120 cols, single mode: `120 - 5 = 115` columns for input  
- Terminal 80 cols, multi mode: `80 - 9 = 71` columns for input

The input now wraps text at the correct position based on available terminal width.

<img width="1450" height="1968" alt="CleanShot 2025-12-29 at 20 27 54@2x" src="https://github.com/user-attachments/assets/d3cc66a0-5604-48a7-a9a7-afc234b58d18" />

## Test plan

- [ ] Test with narrow terminal (< 80 columns)
- [ ] Test with wide terminal (> 120 columns)
- [ ] Test terminal resize while input is focused
- [ ] Test both single-select and multi-select modes
- [ ] Verify long text wraps instead of truncating with `...`