### PR TITLE
feat: add nvidia and canopywave provider support

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1881,6 +1881,36 @@ export const providers: ProvidersMap = {
       })(name);
     },
   },
+  nvidia: {
+    id: 'nvidia',
+    env: ['NVIDIA_API_KEY'],
+    name: 'NVIDIA',
+    api: 'https://integrate.api.nvidia.com/v1/',
+    doc: 'https://nvidia.com/',
+    models: {
+      'z-ai/glm4.7': models['glm-4.7'],
+      'minimaxai/minimax-m2.1': models['minimax-m2.1'],
+      'moonshotai/kimi-k2-thinking': models['kimi-k2-thinking'],
+      'openai/gpt-oss-120b': models['gpt-oss-120b'],
+      'qwen/qwen3-coder-480b-a35b-instruct':
+        models['qwen3-coder-480b-a35b-instruct'],
+    },
+    createModel: defaultModelCreator,
+  },
+  canopywave: {
+    id: 'canopywave',
+    env: ['CANOPYWAVE_API_KEY'],
+    name: 'CanopyWave',
+    api: 'https://inference.canopywave.io/v1',
+    doc: 'https://canopywave.io/',
+    models: {
+      'minimax/minimax-m2.1': models['minimax-m2.1'],
+      'zai/glm-4.7': models['glm-4.7'],
+      'moonshotai/kimi-k2-thinking': models['kimi-k2-thinking'],
+      'deepseek/deepseek-chat-v3.2': models['deepseek-v3-2-exp'],
+    },
+    createModel: defaultModelCreator,
+  },
 };
 
 // value format: provider/model


### PR DESCRIPTION
Added support for NVIDIA and CanopyWave API providers with their respective models and configurations.