### PR TITLE
fix: prevent slash commands on multiline input

### DIFF
--- a/src/ui/useSlashCommands.ts
+++ b/src/ui/useSlashCommands.ts
@@ -9,7 +9,7 @@ export function useSlashCommands(input: string) {
   const [isLoading, setIsLoading] = useState(false);
 
   const suggestions = useMemo(() => {
-    if (!input.startsWith('/')) {
+    if (!input.startsWith('/') || input.includes('\n')) {
       return [];
     }
     const commandPrefix = input.slice(1);


### PR DESCRIPTION
Added check to prevent slash command suggestions when input contains newlines.

The problem:

<img width="237" height="146" alt="iTerm2 2026-01-09 16 03 58" src="https://github.com/user-attachments/assets/224518d3-9422-455d-9018-e749ee1096bb" />
