### PR TITLE
fix: handle canceled error type in ui store

### DIFF
--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -832,7 +832,10 @@ export const useAppStore = create<AppStore>()(
             forkParentUuid: null,
           });
         } else {
-          if (response.error.type === 'tool_denied') {
+          if (
+            response.error.type === 'tool_denied' ||
+            response.error.type === 'canceled'
+          ) {
             set({
               status: 'idle',
               processingStartTime: null,


### PR DESCRIPTION
Added handling for 'canceled' error type to properly reset UI state when operations are canceled.

before.

```
chencheng
[Request interrupted by user] 

Failed: Operation was canceled
```

after.

```
chencheng
[Request interrupted by user] 
```