### PR TITLE
refactor: move arg parsing to cli

### DIFF
--- a/docs/designs/2026-01-13-move-arg-parsing-to-cli.md
+++ b/docs/designs/2026-01-13-move-arg-parsing-to-cli.md
@@ -1,0 +1,75 @@
+# Move Arg Parsing to cli.ts
+
+**Date:** 2026-01-13
+
+## Context
+
+The current architecture has `cli.ts` as a thin entry point (28 lines) that only reads package.json and calls `runNeovate()`. All argument parsing logic resides in `index.ts` (498 lines), which handles everything: arg parsing, help text, quiet mode, interactive mode, and command routing.
+
+The goal is to refactor so that argument parsing happens in `cli.ts` before calling `runNeovate()`, providing better separation of concerns.
+
+## Discussion
+
+**Q: What should cli.ts do with the parsed args?**
+- Option considered: Parse & handle commands directly in cli.ts
+- Option considered: Full command routing in cli.ts
+- **Chosen:** Parse args in cli.ts, pass to `runNeovate()`. Keep `parseArgs()` function defined in index.ts and import it to cli.ts.
+
+**Q: Should the Argv type be exported?**
+- **Chosen:** Export the `Argv` type from index.ts for type safety in cli.ts.
+
+**Q: How should runNeovate() receive the parsed argv?**
+- Option considered: Create a new `runNeovateWithArgv()` function
+- **Chosen:** Add `argv: Argv` as a new required parameter to `runNeovate(opts)`.
+
+## Approach
+
+1. Export `parseArgs` function and `Argv` type from `index.ts`
+2. Modify `runNeovate()` to accept `argv` in its options parameter
+3. Remove the internal `parseArgs()` call from `runNeovate()`
+4. In `cli.ts`, import `parseArgs` and `Argv`, call parsing before `runNeovate()`, and pass the result
+
+## Architecture
+
+### index.ts exports
+
+```typescript
+export { parseArgs };
+export type { Argv };
+
+export async function runNeovate(opts: {
+  productName: string;
+  productASCIIArt?: string;
+  version: string;
+  plugins: Plugin[];
+  upgrade?: UpgradeOptions;
+  argv: Argv;  // NEW required field
+}) { ... }
+```
+
+### cli.ts changes
+
+```typescript
+import { runNeovate, parseArgs, type Argv } from '.';
+
+const argv = await parseArgs(process.argv.slice(2));
+runNeovate({
+  productName: PRODUCT_NAME,
+  productASCIIArt: PRODUCT_ASCII_ART,
+  version: pkg.version,
+  plugins: [],
+  upgrade: { ... },
+  argv,
+});
+```
+
+### Breaking Change
+
+`runNeovate()` now requires `argv` parameter. Any SDK consumers calling `runNeovate()` directly will need to provide parsed args.
+
+### Estimated Changes
+
+| File | Changes |
+|------|---------|
+| `src/index.ts` | ~10 lines modified |
+| `src/cli.ts` | ~5 lines added |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'pathe';
 import { fileURLToPath } from 'url';
-import { runNeovate } from '.';
+import { parseArgs, runNeovate } from '.';
 import { PRODUCT_ASCII_ART, PRODUCT_NAME } from './constants';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -10,6 +10,9 @@ const pkg = JSON.parse(
   fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'),
 );
 const installDir = path.resolve(__dirname, '../');
+
+const argv = await parseArgs(process.argv.slice(2));
+
 runNeovate({
   productName: PRODUCT_NAME,
   productASCIIArt: PRODUCT_ASCII_ART,
@@ -22,6 +25,7 @@ runNeovate({
     installDir,
     files: ['vendor', 'dist', 'package.json'],
   },
+  argv,
 }).catch((e) => {
   console.error(e);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type { Plugin, Context };
 // https://github.com/yargs/yargs-parser/blob/6d69295/lib/index.ts#L19
 process.env.YARGS_MIN_NODE_VERSION = '18';
 
-type Argv = {
+export type Argv = {
   _: string[];
   // boolean
   help: boolean;
@@ -70,7 +70,7 @@ type Argv = {
   mcpConfig: string[];
 };
 
-async function parseArgs(argv: any) {
+export async function parseArgs(argv: any) {
   const { default: yargsParser } = await import('yargs-parser');
   const args = yargsParser(argv, {
     alias: {
@@ -334,8 +334,9 @@ export async function runNeovate(opts: {
   version: string;
   plugins: Plugin[];
   upgrade?: UpgradeOptions;
+  argv: Argv;
 }) {
-  const argv = await parseArgs(process.argv.slice(2));
+  const argv = opts.argv;
   const cwd = argv.cwd || process.cwd();
 
   // Parse MCP config if provided


### PR DESCRIPTION
Moved argument parsing from runNeovate to cli.ts entry point for better separation of concerns. Exported Argv type and parseArgs function, and made argv a required parameter for runNeovate.