### PR TITLE
refactor(server): decouple shutdown logic from process exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ src/
 - Use `zod` for runtime type validation
 - Suffix tool classes with 'Tool'
 - Prefer async/await for asynchronous operations
+- Use subagent to run typecheck
 
 Code style is enforced by Biome (see `biome.json`) - don't manually enforce style rules.
 

--- a/docs/designs/2026-01-13-server-shutdown-refactor.md
+++ b/docs/designs/2026-01-13-server-shutdown-refactor.md
@@ -1,0 +1,109 @@
+# Server Shutdown Function Refactor
+
+**Date:** 2026-01-13
+
+## Context
+
+The server command in `src/commands/server/server.ts` had tightly coupled shutdown logic with `process.exit()` calls and signal handlers (`SIGINT`/`SIGTERM`) embedded directly within the function. This made it difficult to use programmatically (e.g., from SDK or tests) where the caller may want to control the lifecycle without the process exiting immediately.
+
+Additionally, signal handlers were scattered across multiple locations (`runServer`, `runQuiet`, `runInteractive`), making the codebase harder to maintain.
+
+## Discussion
+
+Key questions and decisions:
+
+1. **Should the shutdown function call `process.exit()`?**
+   - Decision: No. The shutdown function should only stop the server. Process exit should only happen when signal handlers are triggered.
+
+2. **Should `runServer` register SIGINT/SIGTERM handlers?**
+   - Decision: No. The caller is responsible for registering signal handlers. This enables programmatic control.
+
+3. **What should `runNeovate` return?**
+   - Options considered:
+     - `() => Promise<void> | undefined`
+     - `{ shutdown?: () => Promise<void> }`
+   - Decision: Return `{ shutdown?: () => Promise<void> }` for clarity and extensibility.
+
+4. **Should all commands return a shutdown function?**
+   - Decision: Only the server command returns a shutdown function. Other commands return an empty object.
+
+5. **Where should signal handlers live?**
+   - Decision: Consolidate all `process.on('SIGINT'/'SIGTERM')` handlers in `cli.ts` as a single entry point.
+
+## Approach
+
+1. **server.ts**: Remove `process.exit()` calls and signal handlers from `runServer`. Return the shutdown function directly.
+
+2. **index.ts**: 
+   - Remove signal handlers from `runQuiet` and `runInteractive`
+   - Change `runNeovate` return type to `Promise<{ shutdown?: () => Promise<void> }>`
+   - Return `{ shutdown }` only for server command, empty `{}` for others
+
+3. **cli.ts**: Register a single signal handler that:
+   - Calls `shutdown()` if provided (server command)
+   - Calls `process.exit()` after shutdown completes
+   - Handles both SIGINT and SIGTERM uniformly
+
+## Architecture
+
+### Flow Diagram
+
+```
+cli.ts
+  │
+  ├─► runNeovate() ─► returns { shutdown? }
+  │
+  └─► process.on('SIGINT'/'SIGTERM')
+        │
+        └─► if shutdown exists: await shutdown()
+        └─► process.exit(0)
+```
+
+### Type Signatures
+
+```typescript
+// server.ts
+export async function runServer(opts: {
+  cwd: string;
+  contextCreateOpts: any;
+}): Promise<() => Promise<void>>
+
+// index.ts
+export async function runNeovate(opts: {
+  productName: string;
+  productASCIIArt?: string;
+  version: string;
+  plugins: Plugin[];
+  upgrade?: UpgradeOptions;
+  argv: Argv;
+}): Promise<{ shutdown?: () => Promise<void> }>
+```
+
+### Signal Handler Implementation
+
+```typescript
+// cli.ts
+let isShuttingDown = false;
+const handleSignal = async () => {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  try {
+    if (shutdown) {
+      await shutdown();
+    }
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during shutdown:', error);
+    process.exit(1);
+  }
+};
+process.on('SIGINT', handleSignal);
+process.on('SIGTERM', handleSignal);
+```
+
+### Benefits
+
+- **Testability**: Server can be started/stopped programmatically without process exit
+- **SDK-friendly**: Consumers can control lifecycle
+- **Maintainability**: Single location for all signal handling
+- **Consistency**: Uniform shutdown behavior across all commands

--- a/scripts/test-run-server.ts
+++ b/scripts/test-run-server.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+
+import readline from 'readline';
+
+interface ParsedArgs {
+  help: boolean;
+  port?: number;
+  host?: string;
+}
+
+function parseArgs(): ParsedArgs {
+  const args = Bun.argv.slice(2);
+  const result: ParsedArgs = { help: false };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-h' || arg === '--help') {
+      result.help = true;
+    } else if (arg === '-p' || arg === '--port') {
+      result.port = Number.parseInt(args[++i], 10);
+    } else if (arg === '--host') {
+      result.host = args[++i];
+    }
+  }
+
+  return result;
+}
+
+function showHelp(): void {
+  console.log(`
+Usage: bun scripts/test-run-server.ts [options]
+
+Run the server command in quiet mode for development/testing.
+
+Options:
+  -h, --help       Show this help message
+  -p, --port       Port number (default: 1024)
+  --host           Host address (default: 127.0.0.1)
+
+Examples:
+  bun scripts/test-run-server.ts
+  bun scripts/test-run-server.ts -p 3000
+  bun scripts/test-run-server.ts --port 8080 --host 0.0.0.0
+`);
+}
+
+async function confirm(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`${message} (y/n): `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (args.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  const serverArgs = ['server'];
+  if (args.port) serverArgs.push('-p', String(args.port));
+  if (args.host) serverArgs.push('-h', args.host);
+
+  const { parseArgs: neovateParseArgs, runNeovate } = await import(
+    '../src/index'
+  );
+
+  const argv = await neovateParseArgs(['--quiet', ...serverArgs]);
+
+  console.log('Starting server in quiet mode...');
+  const { shutdown } = await runNeovate({
+    productName: 'neovate',
+    version: 'dev',
+    plugins: [],
+    argv,
+  });
+
+  if (!shutdown) {
+    console.log('Server did not return shutdown function');
+    process.exit(1);
+  }
+
+  console.log('\nServer is running.');
+
+  const shouldStop = await confirm('Stop server?');
+  if (shouldStop) {
+    await shutdown();
+    console.log('Server stopped.');
+  } else {
+    console.log('Server continues running. Press Ctrl+C to stop.');
+    await new Promise(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const installDir = path.resolve(__dirname, '../');
 
 const argv = await parseArgs(process.argv.slice(2));
 
-runNeovate({
+const { shutdown } = await runNeovate({
   productName: PRODUCT_NAME,
   productASCIIArt: PRODUCT_ASCII_ART,
   version: pkg.version,
@@ -26,6 +26,21 @@ runNeovate({
     files: ['vendor', 'dist', 'package.json'],
   },
   argv,
-}).catch((e) => {
-  console.error(e);
 });
+
+let isShuttingDown = false;
+const handleSignal = async () => {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  try {
+    if (shutdown) {
+      await shutdown();
+    }
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during shutdown:', error);
+    process.exit(1);
+  }
+};
+process.on('SIGINT', handleSignal);
+process.on('SIGTERM', handleSignal);

--- a/src/commands/server/server.ts
+++ b/src/commands/server/server.ts
@@ -4,7 +4,10 @@ import { WebServer } from './web-server';
 const DEFAULT_PORT = 1024;
 const DEFAULT_HOST = '127.0.0.1';
 
-export async function runServer(opts: { cwd: string; contextCreateOpts: any }) {
+export async function runServer(opts: {
+  cwd: string;
+  contextCreateOpts: any;
+}): Promise<() => Promise<void>> {
   const { default: yargsParser } = await import('yargs-parser');
   const argv = yargsParser(process.argv.slice(2), {
     alias: {
@@ -26,29 +29,12 @@ export async function runServer(opts: { cwd: string; contextCreateOpts: any }) {
     cwd: opts.cwd,
   });
 
-  let isShuttingDown = false;
-
   const shutdown = async () => {
-    if (isShuttingDown) return;
-    isShuttingDown = true;
-
     console.log('\n[WebServer] Shutting down...');
-    try {
-      await server.stop();
-      process.exit(0);
-    } catch (error) {
-      console.error('[WebServer] Error during shutdown:', error);
-      process.exit(1);
-    }
+    await server.stop();
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  await server.start();
 
-  try {
-    await server.start();
-  } catch (error) {
-    console.error('Failed to start server:', error);
-    process.exit(1);
-  }
+  return shutdown;
 }


### PR DESCRIPTION
Refactored server shutdown to decouple from process.exit() by returning a shutdown function runNeovate. Signal handlers are now consolidated in cli.ts, enabling programmatic control and better testability.