### PR TITLE
chore: support swagger for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "@fastify/compress": "8.3.0",
     "@fastify/cors": "11.2.0",
     "@fastify/static": "^8.3.0",
+    "@fastify/swagger": "^9.6.1",
+    "@fastify/swagger-ui": "^5.2.4",
     "@fastify/type-provider-typebox": "6.1.0",
     "@microsoft/api-extractor": "^7.55.2",
     "@modelcontextprotocol/inspector": "^0.17.5",
@@ -149,9 +151,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@fastify/swagger": "^9.6.1",
-    "@fastify/swagger-ui": "^5.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,6 @@ patchedDependencies:
 importers:
 
   .:
-    dependencies:
-      '@fastify/swagger':
-        specifier: ^9.6.1
-        version: 9.6.1
-      '@fastify/swagger-ui':
-        specifier: ^5.2.4
-        version: 5.2.4
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^2.0.56
@@ -64,6 +57,12 @@ importers:
       '@fastify/static':
         specifier: ^8.3.0
         version: 8.3.0
+      '@fastify/swagger':
+        specifier: ^9.6.1
+        version: 9.6.1
+      '@fastify/swagger-ui':
+        specifier: ^5.2.4
+        version: 5.2.4
       '@fastify/type-provider-typebox':
         specifier: 6.1.0
         version: 6.1.0(typebox@1.0.41)

--- a/src/commands/server/web-server.ts
+++ b/src/commands/server/web-server.ts
@@ -51,29 +51,35 @@ class WebServer {
     }).withTypeProvider<TypeBoxTypeProvider>();
   }
 
-  private async registerPlugins() {
-    await this.app.register(import('@fastify/swagger'), {
-      openapi: {
-        info: {
-          title: 'Neovate Code API',
-          description: 'API documentation for Neovate Code Server',
-          version: '0.1.0',
-        },
-        servers: [
-          {
-            url: `http://${this.host}:${this.port}`,
+  private async registerSwagger() {
+    if (isLocal()) {
+      await this.app.register(import('@fastify/swagger'), {
+        openapi: {
+          info: {
+            title: 'Neovate Code API',
+            description: 'API documentation for Neovate Code Server',
+            version: '0.1.0',
           },
-        ],
-      },
-    });
+          servers: [
+            {
+              url: `http://${this.host}:${this.port}`,
+            },
+          ],
+        },
+      });
 
-    await this.app.register(import('@fastify/swagger-ui'), {
-      routePrefix: '/documentation',
-      uiConfig: {
-        docExpansion: 'full',
-        deepLinking: false,
-      },
-    });
+      await this.app.register(import('@fastify/swagger-ui'), {
+        routePrefix: '/documentation',
+        uiConfig: {
+          docExpansion: 'full',
+          deepLinking: false,
+        },
+      });
+    }
+  }
+
+  private async registerPlugins() {
+    await this.registerSwagger();
 
     await this.app.register(import('@fastify/cors'), {
       origin: true,


### PR DESCRIPTION
Add swagger support to the server mode, and then the api code can be automatically generated on the desktop