### PR TITLE
fix(security): normalize paths to prevent traversal bypass on Windows

### DIFF
--- a/src/commands/server/routes/files.ts
+++ b/src/commands/server/routes/files.ts
@@ -32,7 +32,7 @@ const filesRoute: FastifyPluginAsync<ContextCreateOpts> = async (app, opts) => {
     async (request, reply) => {
       try {
         const { filePath } = request.query;
-        const cwd = opts.cwd;
+        const cwd = path.resolve(opts.cwd);
         const absolutePath = path.resolve(cwd, filePath);
 
         if (!absolutePath.startsWith(cwd)) {
@@ -80,7 +80,7 @@ const filesRoute: FastifyPluginAsync<ContextCreateOpts> = async (app, opts) => {
     async (request, reply) => {
       try {
         const { filePath, content } = request.body;
-        const cwd = opts.cwd;
+        const cwd = path.resolve(opts.cwd);
         const absolutePath = path.resolve(cwd, filePath);
 
         if (!absolutePath.startsWith(cwd)) {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -56,7 +56,8 @@ async function processImage(
 
     // Security: Validate file path to prevent traversal attacks
     const resolvedPath = path.resolve(filePath);
-    if (!resolvedPath.startsWith(cwd)) {
+    const normalizedCwd = path.resolve(cwd);
+    if (!resolvedPath.startsWith(normalizedCwd)) {
       throw new Error('Invalid file path: path traversal detected');
     }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -543,9 +543,10 @@ export async function getWorktreeFromPath(cwd: string): Promise<Worktree> {
   const gitRoot = await getGitRoot(cwd);
   const worktrees = await listWorktrees(gitRoot);
 
+  const normalizedCwd = path.resolve(cwd);
   // Check if current path is inside a worktree
   for (const worktree of worktrees) {
-    if (cwd.startsWith(worktree.path)) {
+    if (normalizedCwd.startsWith(path.resolve(worktree.path))) {
       return worktree;
     }
   }


### PR DESCRIPTION
Fixes an issue where path traversal detection failed on Windows due to 
inconsistent path separators (/ vs \). By using path.resolve(), we ensure 
both resolved path and CWD use the same normalization before startsWith check.

Affected areas:
- src/tools/read.ts
- src/commands/server/routes/files.ts
- src/worktree.ts