### PR TITLE
feat: add custom provider support to SDK

### DIFF
--- a/scripts/test-sdk.tsx
+++ b/scripts/test-sdk.tsx
@@ -2,7 +2,12 @@ import { Box, render, Text, useApp, useInput } from 'ink';
 import React, { useState } from 'react';
 import { createSession, prompt, resumeSession } from '../src/sdk';
 
-type TestMode = 'menu' | 'send' | 'prompt' | 'resume';
+type TestMode =
+  | 'menu'
+  | 'send'
+  | 'prompt'
+  | 'prompt-custom-provider'
+  | 'resume';
 
 function App() {
   const { exit } = useApp();
@@ -14,6 +19,10 @@ function App() {
   const options = [
     { label: 'Test send (createSession + send + receive)', value: 'send' },
     { label: 'Test prompt (one-shot)', value: 'prompt' },
+    {
+      label: 'Test prompt with custom provider (foooo/claude-haiku-4-5)',
+      value: 'prompt-custom-provider',
+    },
     {
       label: 'Test resume (resumeSession with last session)',
       value: 'resume',
@@ -28,7 +37,7 @@ function App() {
     setIsRunning(true);
     addOutput('Creating SDK session...');
     const session = await createSession({
-      model: 'anthropic/claude-sonnet-4-20250514',
+      model: 'modelwatch/qwen3-coder-plus',
     });
     addOutput(`Session created: ${session.sessionId}`);
     addOutput(
@@ -48,7 +57,7 @@ function App() {
 
   const testResume = async () => {
     setIsRunning(true);
-    const modelOptions = { model: 'anthropic/claude-sonnet-4-20250514' };
+    const modelOptions = { model: 'modelwatch/qwen3-coder-plus' };
 
     addOutput('Step 1: Creating initial session...');
     const session1 = await createSession(modelOptions);
@@ -89,9 +98,38 @@ function App() {
     const result = await prompt(
       'fetch https://makojs.dev/blog/mako-internal-test and summarize',
       {
-        model: 'anthropic/claude-sonnet-4-20250514',
+        model: 'modelwatch/qwen3-coder-plus',
       },
     );
+    addOutput('\nResult:');
+    addOutput(JSON.stringify(result, null, 2));
+    setIsRunning(false);
+  };
+
+  const testPromptWithCustomProvider = async () => {
+    setIsRunning(true);
+    addOutput('Testing prompt with custom provider "foooo"...');
+    addOutput('Provider config:');
+    addOutput('  - baseURL: http://127.0.0.1:8045/v1/');
+    addOutput('  - createModelType: anthropic');
+    addOutput('  - model: foooo/claude-haiku-4-5');
+    addOutput('');
+    addOutput('Calling prompt("what is 1 + 1?")...');
+    const result = await prompt('what is 1 + 1?', {
+      model: 'foooo/claude-haiku-4-5',
+      providers: {
+        foooo: {
+          options: {
+            baseURL: 'http://127.0.0.1:8045/v1/',
+            apiKey: 'sk-loveyyx822',
+          },
+          models: {
+            'claude-haiku-4-5': 'claude-haiku-4-5',
+          },
+          createModelType: 'anthropic',
+        },
+      },
+    });
     addOutput('\nResult:');
     addOutput(JSON.stringify(result, null, 2));
     setIsRunning(false);
@@ -113,6 +151,10 @@ function App() {
           testSend().catch((e) => addOutput(`Error: ${e.message}`));
         } else if (selected === 'prompt') {
           testPrompt().catch((e) => addOutput(`Error: ${e.message}`));
+        } else if (selected === 'prompt-custom-provider') {
+          testPromptWithCustomProvider().catch((e) =>
+            addOutput(`Error: ${e.message}`),
+          );
         } else if (selected === 'resume') {
           testResume().catch((e) => addOutput(`Error: ${e.message}`));
         }
@@ -154,7 +196,9 @@ function App() {
           ? 'Testing send'
           : mode === 'prompt'
             ? 'Testing prompt'
-            : 'Testing resume'}
+            : mode === 'prompt-custom-provider'
+              ? 'Testing prompt with custom provider'
+              : 'Testing resume'}
       </Text>
       <Text dimColor>{isRunning ? 'Running...' : 'Press q to go back'}</Text>
       <Box flexDirection="column" marginTop={1}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export {
   type SDKSessionOptions,
   type SDKUserMessage,
 } from './sdk';
+export type { ProviderConfig } from './config';
 export { createTool } from './tool';
 
 export type { Plugin, Context };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,3 +1,4 @@
+import type { ProviderConfig } from './config';
 import type {
   NormalizedMessage,
   SDKResultMessage,
@@ -19,6 +20,24 @@ export type SDKSessionOptions = {
   cwd?: string;
   productName?: string;
   plugins?: Plugin[];
+  /**
+   * Custom provider configurations to add or override built-in providers.
+   * Allows specifying custom API endpoints and model definitions.
+   *
+   * @example
+   * ```typescript
+   * providers: {
+   *   "my-custom-provider": {
+   *     api: "https://my-api.example.com/v1",
+   *     env: ["MY_API_KEY"],
+   *     models: {
+   *       "my-model": "deepseek-v3.2" // Reference existing model
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  providers?: Record<string, ProviderConfig>;
 };
 
 export type SDKUserMessage = {
@@ -248,6 +267,8 @@ function createBridgePair(options: SDKSessionOptions): {
       version: '0.0.0',
       argvConfig: {
         model: options.model,
+        // Pass custom providers to be merged with built-in providers
+        provider: options.providers,
       },
       plugins: options.plugins || [],
     },


### PR DESCRIPTION
Added support for custom provider configurations in SDKSessionOptions, allowing users to specify custom API endpoints and model definitions. The change also exports the ProviderConfig type and includes a test case for custom providers.