### PR TITLE
refactor: remove unused tool approval logic

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -134,7 +134,8 @@ export class Project {
       model: opts.model || this.context.config.planModel,
       tools,
       systemPrompt,
-      onToolApprove: () => Promise.resolve(true),
+      // why? askUserQuestion tool will always require user input, so we don't need to approve it
+      // onToolApprove: () => Promise.resolve(true),
     });
   }
 


### PR DESCRIPTION
Removed redundant onToolApprove callback as askUserQuestion tool inherently requires user input.
fix 计划模式因自动批准导致 askUserQuestion 不可用
<img width="950" height="235" alt="image" src="https://github.com/user-attachments/assets/3c175dd7-c004-4183-b27b-f0269a50115a" />
