### PR TITLE
fix(mcp): Fix spawn npx ENOENT error on Windows

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -334,11 +334,19 @@ export class MCPManager {
       const { Experimental_StdioMCPTransport } = await import(
         '@ai-sdk/mcp/mcp-stdio'
       );
-
+      // windows:if command is npx,npm,yarn,pnpm,use cmd.exe to execute,fix:spawn npx ENOENT error
+      const windowsShellCommands = ['npx', 'npm', 'yarn', 'pnpm'];
+      let command = config.command;
+      let args = config.args;
+      const isWin = process.platform === 'win32';
+      if (isWin && windowsShellCommands.includes(command)) {
+        args = ['/c', command, ...(args||[])];
+        command = 'cmd.exe';
+      }
       return experimental_createMCPClient({
         transport: new Experimental_StdioMCPTransport({
-          command: config.command,
-          args: config.args,
+          command,
+          args,
           stderr: 'ignore',
           env,
         }),


### PR DESCRIPTION
On Windows platform, when executing package manager commands like npx, npm, yarn, or pnpm,
use cmd.exe /c to execute them to resolve the ENOENT error that occurs when spawning commands directly.

Fix details:
- Add Windows platform detection
- Use cmd.exe to execute specified package manager commands
- Properly handle command argument passing

Impact: Only affects MCP clients using stdio transport on Windows platform