### PR TITLE
Fix/win32 spawn npx enoent error

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -340,7 +340,7 @@ export class MCPManager {
       let args = config.args;
       const isWin = process.platform === 'win32';
       if (isWin && windowsShellCommands.includes(command)) {
-        args = ['/c', command, ...(args||[])];
+        args = ['/c', command, ...(args || [])];
         command = 'cmd.exe';
       }
       return experimental_createMCPClient({


### PR DESCRIPTION
On Windows platform, when executing package manager commands like npx, npm, yarn, or pnpm,
use cmd.exe /c to execute them to resolve the ENOENT error that occurs when spawning commands directly.

Fix details:
- Add Windows platform detection
- Use cmd.exe to execute specified package manager commands
- Properly handle command argument passing

Impact: Only affects MCP clients using stdio transport on Windows platform