### PR TITLE
refactor: rename createModelType to apiFormat

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -80,7 +80,7 @@ export interface Provider {
       setGlobalConfig: (key: string, value: string, isGlobal: boolean) => void;
     },
   ) => Promise<LanguageModelV2> | LanguageModelV2;
-  createModelType?: 'anthropic' | 'openai' | 'responses';
+  apiFormat?: 'anthropic' | 'openai' | 'responses';
   options?: {
     baseURL?: string;
     apiKey?: string;
@@ -1410,7 +1410,7 @@ export const providers: ProvidersMap = {
       'claude-haiku-4-5': models['claude-haiku-4-5'],
       'claude-opus-4-5': models['claude-opus-4-5'],
     },
-    createModelType: 'anthropic',
+    apiFormat: 'anthropic',
     createModel: defaultAnthropicModelCreator,
   },
   aihubmix: {
@@ -2033,7 +2033,7 @@ function mergeConfigProviders(
         openai: defaultModelCreator,
         responses: openaiModelResponseCreator,
       };
-      const type = provider.createModelType || 'openai';
+      const type = provider.apiFormat || 'openai';
       provider.createModel = creatorMap[type];
     }
     if (provider.models) {

--- a/src/thinking-config.ts
+++ b/src/thinking-config.ts
@@ -69,7 +69,7 @@ export function getThinkingConfig(
     (model.provider.id === 'modelwatch' &&
       model.model.id.startsWith('claude-')) ||
     model.model.id.startsWith('gemini-') ||
-    (model.provider.createModelType === 'anthropic' && model.model.reasoning)
+    (model.provider.apiFormat === 'anthropic' && model.model.reasoning)
   ) {
     return {
       providerOptions: {


### PR DESCRIPTION
Renamed Provider interface property createModelType to apiFormat for better semantic clarity, as it defines the API format used for model interactions.