### PR TITLE
feat: enhance prompt caching and api format support

### DIFF
--- a/src/promptCache.ts
+++ b/src/promptCache.ts
@@ -6,27 +6,50 @@ export function addPromptCache(
   model: ModelInfo,
 ): LanguageModelV3Prompt {
   const modelId = model.model.id.toLowerCase();
-  const shouldCache = modelId.includes('sonnet') || modelId.includes('opus');
+  const providerId = model.provider.id;
+
+  const shouldCache =
+    modelId.includes('claude') ||
+    modelId.includes('sonnet') ||
+    modelId.includes('opus');
 
   if (!shouldCache) {
     return prompt;
   }
 
-  let systemMessageCount = 0;
+  const providerOptions = {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+    openrouter: { cacheControl: { type: 'ephemeral' } },
+    bedrock: { cachePoint: { type: 'ephemeral' } },
+    openaiCompatible: { cache_control: { type: 'ephemeral' } },
+  };
+
+  const system = prompt.filter((msg) => msg.role === 'system').slice(0, 2);
+  const nonSystem = prompt.filter((msg) => msg.role !== 'system').slice(-2);
+  const toCache = new Set([...system, ...nonSystem]);
+
   return prompt.map((message) => {
-    if (message.role === 'system' && systemMessageCount < 4) {
-      systemMessageCount++;
-      return {
-        ...message,
-        providerOptions: {
-          ...(message.providerOptions || {}),
-          anthropic: {
-            ...(message.providerOptions?.anthropic || {}),
-            cacheControl: { type: 'ephemeral' },
-          },
-        },
-      };
+    if (!toCache.has(message)) return message;
+
+    if (
+      providerId !== 'anthropic' &&
+      Array.isArray(message.content) &&
+      message.content.length > 0
+    ) {
+      const content = [...message.content];
+      const last = content[content.length - 1];
+      if (last && typeof last === 'object') {
+        content[content.length - 1] = {
+          ...last,
+          providerOptions: { ...last.providerOptions, ...providerOptions },
+        };
+        return { ...message, content };
+      }
     }
-    return message;
-  });
+
+    return {
+      ...message,
+      providerOptions: { ...message.providerOptions, ...providerOptions },
+    };
+  }) as LanguageModelV3Prompt;
 }

--- a/src/provider/model.ts
+++ b/src/provider/model.ts
@@ -128,7 +128,9 @@ function transformVariants(model: Model, provider: Provider) {
     return {};
   }
 
-  if (provider.apiFormat === ApiFormat.OpenAI) {
+  const apiFormat = model.apiFormat || provider.apiFormat;
+
+  if (apiFormat === ApiFormat.OpenAI) {
     const WIDELY_SUPPORTED_EFFORTS = ['low', 'medium', 'high'];
     return Object.fromEntries(
       WIDELY_SUPPORTED_EFFORTS.map((effort) => [
@@ -142,7 +144,7 @@ function transformVariants(model: Model, provider: Provider) {
     );
   }
 
-  if (provider.apiFormat === ApiFormat.Anthropic) {
+  if (apiFormat === ApiFormat.Anthropic) {
     if (provider.id === 'xiaomi') {
       return {
         on: {
@@ -171,7 +173,7 @@ function transformVariants(model: Model, provider: Provider) {
     };
   }
 
-  if (provider.apiFormat === ApiFormat.Google) {
+  if (apiFormat === ApiFormat.Google) {
     // https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#gemini-3-models
     if (id.includes('2.5')) {
       return {
@@ -189,6 +191,7 @@ function transformVariants(model: Model, provider: Provider) {
         },
       };
     }
+
     return Object.fromEntries(
       ['low', 'high'].map((effort) => [
         effort,


### PR DESCRIPTION
Extended prompt caching to support multiple providers (Anthropic, OpenRouter, Bedrock, OpenAI-compatible) with provider-specific options. Modified caching strategy to cache first 2 system messages and last 2 non-system messages. Added model-level API format override capability.