### PR TITLE
refactor: simplify approval options for auto-edit modes

### DIFF
--- a/src/ui/PlanMode/PlanApprovalView.tsx
+++ b/src/ui/PlanMode/PlanApprovalView.tsx
@@ -14,7 +14,7 @@ import { useTerminalSize } from '../useTerminalSize';
 export interface PlanApprovalViewProps {
   planFilePath: string;
   planContent: string | null;
-  onApprove: (mode: 'autoEdit' | 'default') => void;
+  onApprove: (mode: 'autoEdit' | 'default' | 'yolo') => void;
   onDeny: (feedback: string) => void;
 }
 
@@ -74,8 +74,8 @@ export function PlanApprovalView({
   const handleChange = useCallback(
     (value: string | string[]) => {
       if (typeof value === 'string') {
-        if (value === 'autoEdit' || value === 'default') {
-          onApprove(value as 'autoEdit' | 'default');
+        if (value === 'autoEdit' || value === 'default' || value === 'yolo') {
+          onApprove(value as 'autoEdit' | 'default' | 'yolo');
           return;
         }
 


### PR DESCRIPTION
计划模式 'autoEdit' or 'yolo' 仅展示确认按钮
<img width="1778" height="1018" alt="image" src="https://github.com/user-attachments/assets/807ee20d-770d-4626-b29e-18a79acece0f" />
