### PR TITLE
fix(textinput): correct tab key handling in useTextInput hook

### DIFF
--- a/src/ui/TextInput/hooks/useTextInput.ts
+++ b/src/ui/TextInput/hooks/useTextInput.ts
@@ -342,9 +342,9 @@ export function useTextInput({
       }
       case key.return:
         return () => handleEnter(key);
+      // key.tab is true for both Tab and Shift+Tab, key.shift indicates if Shift was held
       case key.tab:
-      case key.shift && key.tab:
-        return () => onTabPress?.(key.shift && key.tab);
+        return () => onTabPress?.(key.shift);
       case key.upArrow:
         return upOrHistoryUp;
       case key.downArrow:


### PR DESCRIPTION
Fixed tab key handling to properly detect shift key state when tabbing in TextInput component.

Close https://github.com/neovateai/neovate-code/issues/742

家里 Windows 坏了，AI 一键盲修的，但感觉还挺有道理。